### PR TITLE
Add coffee extensions

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -2,4 +2,4 @@
     name: coffeelint
     entry: coffeelint
     language: node
-    files: \.js$
+    files: \.(js|coffee)$


### PR DESCRIPTION
I would like to lint my coffeescript files on hubot, since those extensions are .coffee I added the extension
